### PR TITLE
Target .Net framework 2.0

### DIFF
--- a/Source/ManagedTest/App.config
+++ b/Source/ManagedTest/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.diagnostics>
     <trace autoflush="true" indentsize="0">
@@ -8,6 +8,6 @@
     </trace>
   </system.diagnostics>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
-  </startup>
+    
+  <supportedRuntime version="v2.0.50727"/></startup>
 </configuration>

--- a/Source/ManagedTest/ManagedTest.csproj
+++ b/Source/ManagedTest/ManagedTest.csproj
@@ -9,9 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ManagedTest</RootNamespace>
     <AssemblyName>ManagedTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -80,12 +82,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Source/ManagedTest/Program.cs
+++ b/Source/ManagedTest/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Diagnostics;
 

--- a/Source/Sysinternals.Debug/Sysinternals.Debug.csproj
+++ b/Source/Sysinternals.Debug/Sysinternals.Debug.csproj
@@ -9,8 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sysinternals.Debug</RootNamespace>
     <AssemblyName>Sysinternals.Debug</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,12 +43,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSuppressions.cs" />


### PR DESCRIPTION
I don't see a reason not to target .NET 2.0. The code just worked, if I removed some import statements and references.

If there is a technical reason, what about .NET 3.5 client profile, or separate builds? Also, I'd like to know the reason for my own CLR education.
