### PR TITLE
Update NativeMethods.cs

### DIFF
--- a/Source/Sysinternals.Debug/NativeMethods.cs
+++ b/Source/Sysinternals.Debug/NativeMethods.cs
@@ -142,7 +142,7 @@ namespace Sysinternals.Debug
             returnValue = DeviceIoControl(hProcMon, 
                                           IOCTL_EXTERNAL_LOG_DEBUGOUT,
                                           renderedMessage, 
-                                          (uint)(message.Length * sizeof(System.Char)),
+                                          (uint)(renderedMessage.Length * sizeof(System.Char)),
                                           IntPtr.Zero, 
                                           0, 
                                           out outLen, 


### PR DESCRIPTION
Was not calculating length of the message buffer right. It was working ok untill I passed large strings into the formatters.
